### PR TITLE
Fix: Resolve consensus deadlock in PrepareMaker aggregator

### DIFF
--- a/consensus/src/aggregator.rs
+++ b/consensus/src/aggregator.rs
@@ -169,7 +169,7 @@ impl PrepareMaker {
         }
         let total = self.optnum + self.pesnum;
 
-        if total == committee.quorum_threshold() {
+        if total >= committee.quorum_threshold() {
             if prepare.phase == PRE_ONE {
                 if self.optnum >= committee.quorum_threshold() {
                     return Ok(Some((OPT, true)));


### PR DESCRIPTION
# Fix: Resolve consensus deadlock in PrepareMaker aggregator

### Summary

This pull request addresses a critical deadlock in the consensus module, specifically within the `PrepareMaker` aggregator. The bug causes the consensus process to silently hang after a period of high transaction throughput, especially in an asynchronous network environment.

### Problem Description

While stress-testing the network with a high transaction rate, we observed that the consensus layer would completely stall after some time, while the mempool layer continued to accept transactions.

The root cause was identified in the `PrepareMaker::append` function within `consensus/src/aggregator.rs`. The current logic only checks for `total == committee.quorum_threshold()`. Due to the asynchronous nature of the network, a node can process multiple incoming votes in quick succession. This can cause the `total` vote count to "jump" from a value less than the quorum threshold to a value greater than it, completely skipping the equality check.

When this race condition occurs, the `PrepareMaker` fails to make a decision, even though it has received more than enough votes. Consequently, all nodes get stuck waiting for a decision that will never be made, leading to a network-wide deadlock.

### Proposed Fix

The solution is a simple yet robust change: modifying the comparison operator from `==` to `>=` in the quorum check.

```diff
// consensus/src/aggregator.rs

- if total == committee.quorum_threshold() {
+ if total >= committee.quorum_threshold() {
      // ...
  }
```

This ensures that the `PrepareMaker` makes a decision as soon as it has collected a sufficient number of votes (either exactly the threshold or more), thus preventing the deadlock.
